### PR TITLE
Expose as go module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+    - run: |
+        go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/marguerite/go-stdlib
+
+go 1.14
+
+require (
+	github.com/EricLagergren/go-gnulib v0.0.0-20191129172535-039a51fc60f4 // indirect
+	github.com/marguerite/go-gnulib v0.0.0-20201129052155-646ebc0367a8
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/EricLagergren/go-gnulib v0.0.0-20191129172535-039a51fc60f4 h1:jf1NaERjQnGBXLalg4twohDD2SZYs04AfqKRQDG+iuo=
+github.com/EricLagergren/go-gnulib v0.0.0-20191129172535-039a51fc60f4/go.mod h1:cfaDkn0a/WANftKgBnrbQh019l4tjDkYXRsGLsIbhAg=
+github.com/marguerite/go-gnulib v0.0.0-20201129052155-646ebc0367a8 h1:ygl6WQISmoPOMotDhLBNJDdPWeqK6lHecSJCBGJm6UQ=
+github.com/marguerite/go-gnulib v0.0.0-20201129052155-646ebc0367a8/go.mod h1:3rYBf8gtXz3mUEDnme0ZEuJihv5SxYDYhhuErSa2R/E=
+github.com/marguerite/go-stdlib v0.0.0-20201129053131-f9e87b29ae7b h1:ALvbfhR7GcApRiHWHpOd30+a1q77m62uaNhqdOomlWE=
+github.com/marguerite/go-stdlib v0.0.0-20201129053131-f9e87b29ae7b/go.mod h1:Eh9sXSouLfXNCm7k/5PffYs4qZtBJqRJKlv+boNaqCI=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,12 +1,11 @@
 package runtime
 
 import (
-	"os/exec"
 	"runtime"
 	"strings"
 
-  //"github.com/ericlagergren/go-gnulib/login"
-  "github.com/marguerite/go-gnulib/login"
+	//"github.com/ericlagergren/go-gnulib/login"
+	"github.com/marguerite/go-gnulib/login"
 )
 
 // Is64Bit if the operation system is 64bit system
@@ -20,9 +19,9 @@ func Is64Bit() bool {
 
 // LogName the current login user's name
 func LogName() string {
-  name, err := login.GetLogin()
-  if err != nil {
-    panic(err)
-  }
-  return name
+	name, err := login.GetLogin()
+	if err != nil {
+		panic(err)
+	}
+	return name
 }


### PR DESCRIPTION
This exposes `go-stdlib` as a module and adds a GitHub action to run the tests.

Motivation: be able to build [specfile](https://github.com/openSUSE-zh/specfile) through [Go 1.11/1.12+ module system](https://blog.golang.org/using-go-modules).